### PR TITLE
fix: deprecation warning  > PHP 8.0

### DIFF
--- a/StreetAddress.php
+++ b/StreetAddress.php
@@ -12,6 +12,22 @@ class StreetAddress
      */
     protected $snapshot = [];
 
+    /**
+     * Address fields
+     */
+    public $recipient = '';
+    public $organization = '';
+    public $street_address = '';
+    public $street_address_2 = '';
+    public $street_address_3 = '';
+    public $locality = '';
+    public $dependent_locality = '';
+    public $admin_area = '';
+    public $postal_code = '';
+    public $sorting_code = '';
+    public $country = '';
+    public $country_iso = '';
+    public $origin_iso = '';
 
     /**
      * Consrtuctor can optionally take an array of address lines.


### PR DESCRIPTION
Small fix for warning.
Deprecated: Creation of dynamic property ProcessWire\StreetAddress::$recipient is deprecated in .../site/modules/FieldtypeStreetAddress/StreetAddress.php:30